### PR TITLE
Fixed bug while adding errors to header ErrorGroup

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,7 @@ export function getTableErrorGroups(table) {
     }
 
     // Get row
-    let row = group.rows[error['row-number']]
+    let row = group.rows[error['row-number'] || null]
 
     // Create row
     if (!row) {


### PR DESCRIPTION
# Overview

Fixed bug while adding errors to header ErrorGroup, where only the last error was being added. The ErrorGroup key for header row was `undefined` at reading time but inserted with `key=null`.

Header ErrorGroup read with `undefined` key:
https://github.com/frictionlessdata/goodtables-ui/blob/8a835defbf81ff0936cf69082b517878347a327a/src/helpers.js#L20-L21

Header ErrorGroup insert with `null` key:
https://github.com/frictionlessdata/goodtables-ui/blob/8a835defbf81ff0936cf69082b517878347a327a/src/helpers.js#L52-L53

---

Please preserve this line to notify @roll (lead of this repository)
