### PR TITLE
Add an option that removes the row number for the header row.

### DIFF
--- a/src/components/ErrorGroup.tsx
+++ b/src/components/ErrorGroup.tsx
@@ -114,6 +114,14 @@ function ErrorGroupTable(props: {
     isHeadersVisible,
     skipHeaderIndex,
   } = props
+  let afterFailRowNumber = 1
+  if (rowNumbers[rowNumbers.length - 1]) {
+    afterFailRowNumber = rowNumbers[rowNumbers.length - 1] + 1
+  } else if (skipHeaderIndex) {
+    afterFailRowNumber = 1
+  } else {
+    afterFailRowNumber = 2
+  }
   return (
     <table className="table table-sm">
       <tbody>
@@ -150,9 +158,7 @@ function ErrorGroupTable(props: {
             )
         )}
         <tr className="after-fail">
-          <td className="result-row-index">
-            {rowNumbers[rowNumbers.length - 1] ? rowNumbers[rowNumbers.length - 1] + 1 : 2}
-          </td>
+          <td className="result-row-index">{afterFailRowNumber}</td>
           {errorGroup.headers && errorGroup.headers.map((_header, index) => <td key={index} />)}
         </tr>
       </tbody>

--- a/src/components/ErrorGroup.tsx
+++ b/src/components/ErrorGroup.tsx
@@ -9,10 +9,11 @@ import { ISpec, ISpecError, IErrorGroup } from '../common'
 export interface IErrorGroupProps {
   errorGroup: IErrorGroup
   spec?: ISpec
+  skipHeaderIndex?: boolean
 }
 
 export function ErrorGroup(props: IErrorGroupProps) {
-  const { errorGroup, spec } = props
+  const { errorGroup, spec, skipHeaderIndex } = props
   const [isDetailsVisible, setIsDetailsVisible] = useState(false)
   const [visibleRowsCount, setVisibleRowsCount] = useState(10)
   const specError = getSpecError(errorGroup, spec || defaultSpec)
@@ -81,6 +82,7 @@ export function ErrorGroup(props: IErrorGroupProps) {
               visibleRowsCount={visibleRowsCount}
               rowNumbers={rowNumbers}
               isHeadersVisible={isHeadersVisible}
+              skipHeaderIndex={skipHeaderIndex}
             />
           </div>
         </div>
@@ -102,14 +104,22 @@ function ErrorGroupTable(props: {
   visibleRowsCount: number
   rowNumbers: number[]
   isHeadersVisible: boolean
+  skipHeaderIndex?: boolean
 }) {
-  const { specError, errorGroup, visibleRowsCount, rowNumbers, isHeadersVisible } = props
+  const {
+    specError,
+    errorGroup,
+    visibleRowsCount,
+    rowNumbers,
+    isHeadersVisible,
+    skipHeaderIndex,
+  } = props
   return (
     <table className="table table-sm">
       <tbody>
         {errorGroup.headers && isHeadersVisible && (
           <tr className="before-fail">
-            <td className="text-center">1</td>
+            <td className="text-center">{skipHeaderIndex ? '' : '1'}</td>
             {errorGroup.headers.map((header, index) => (
               <td key={index}>{header}</td>
             ))}

--- a/src/components/ErrorGroup.tsx
+++ b/src/components/ErrorGroup.tsx
@@ -133,7 +133,7 @@ function ErrorGroupTable(props: {
                   style={{ backgroundColor: getRgbaColor(specError, 0.25) }}
                   className="result-row-index"
                 >
-                  {rowNumber || 1}
+                  {rowNumber || (skipHeaderIndex ? '' : 1)}
                 </td>
                 {errorGroup.rows[rowNumber].values.map((value, innerIndex) => (
                   <td

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -10,10 +10,12 @@ import { Table } from './Table'
 export interface IReportProps {
   report: IReport
   spec?: ISpec
+  skipHeaderIndex?: boolean
 }
 
 export function Report(props: IReportProps) {
-  const { report, spec } = props
+  const { report, spec, skipHeaderIndex = false } = props
+  console.log('SKIP HEADER INDEX', skipHeaderIndex)
 
   // Invalid report
   const reportValidation = validateReport(report)
@@ -88,6 +90,7 @@ export function Report(props: IReportProps) {
           tableNumber={index + 1}
           tablesCount={tables.length}
           spec={spec || defaultSpec}
+          skipHeaderIndex={skipHeaderIndex}
         />
       ))}
     </div>

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -15,7 +15,6 @@ export interface IReportProps {
 
 export function Report(props: IReportProps) {
   const { report, spec, skipHeaderIndex = false } = props
-  console.log('SKIP HEADER INDEX', skipHeaderIndex)
 
   // Invalid report
   const reportValidation = validateReport(report)

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -10,10 +10,11 @@ export interface ITableProps {
   tableNumber: number
   tablesCount: number
   spec?: ISpec
+  skipHeaderIndex?: boolean
 }
 
 export function Table(props: ITableProps) {
-  const { table, tableNumber, tablesCount, spec } = props
+  const { table, tableNumber, tablesCount, spec, skipHeaderIndex } = props
   const tableFile = removeBaseUrl(table.source)
   const splitTableFile = splitFilePath(tableFile)
   const errorGroups = getTableErrorGroups(table)
@@ -54,7 +55,12 @@ export function Table(props: ITableProps) {
 
       {/* Error groups */}
       {Object.values(errorGroups).map((errorGroup) => (
-        <ErrorGroup key={errorGroup.code} errorGroup={errorGroup} spec={spec || defaultSpec} />
+        <ErrorGroup
+          key={errorGroup.code}
+          errorGroup={errorGroup}
+          spec={spec || defaultSpec}
+          skipHeaderIndex={skipHeaderIndex}
+        />
       ))}
     </div>
   )


### PR DESCRIPTION
Add an option that removes the row number for the header row.

# Overview

Hey,

For various custom processors we use "1" as the index for the first row of data. It looks like goodtables uses "1" as the index for the header, and then "2" as the index for the first row. I can change the report returned from goodtables-py, but goodtables-ui will still have 1 in the header row. This PR makes an optional parameter to Report that makes it not show an index for the header row

![Screenshot from 2021-03-21 10-45-52](https://user-images.githubusercontent.com/7134143/111900383-9fdd2400-8a32-11eb-872e-eafd4cfd5733.png)

---

Please preserve this line to notify @roll (lead of this repository)
